### PR TITLE
added Federated Meta-Learning client code into scikit-learn

### DIFF
--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -91,6 +91,7 @@ else:
                'naive_bayes', 'neighbors', 'neural_network', 'pipeline',
                'preprocessing', 'random_projection', 'semi_supervised',
                'svm', 'tree', 'discriminant_analysis', 'impute', 'compose',
+               'fml',
                # Non-modules:
                'clone', 'get_config', 'set_config', 'config_context',
                'show_versions']

--- a/sklearn/__init__.py
+++ b/sklearn/__init__.py
@@ -45,7 +45,7 @@ warnings.filterwarnings('always', category=DeprecationWarning,
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = '0.22.dev0'
+__version__ = '0.22.fml0'
 
 
 # On OSX, we can get a runtime error due to multiple OpenMP libraries loaded

--- a/sklearn/fml/__init__.py
+++ b/sklearn/fml/__init__.py
@@ -1,0 +1,7 @@
+"""
+The :mod:`sklearn.fml` module implements Federated Meta Learning
+"""
+
+from .fml_client import FMLClient
+
+__all__ = ['FMLClient']

--- a/sklearn/fml/fml_client.py
+++ b/sklearn/fml/fml_client.py
@@ -1,0 +1,38 @@
+import requests as req
+import json
+
+
+class FMLClient:
+    def __init__(self):
+        return
+
+    def _jprint(self, obj):
+        # create a formatted string of the Python JSON object
+        text = json.dumps(obj, sort_keys=True, indent=4)
+        print(text)
+
+    def _send_msg(self, data):
+        """
+        API call to the federated meta learning server
+        """
+        url = 'http://127.0.0.1:5000/metric'
+        res = req.post(url, json=data)
+        print(res.status_code)
+        return res.json()
+
+    def publish(self, algorithm_name, metric_name, metric_value, dataset_hash):
+        """
+        Publishes the data collected to the federated meta learning API
+        """
+        data = {}
+        data['algorithm_name'] = algorithm_name
+        data['metric_name'] = metric_name
+        data['metric_value'] = metric_value
+        data['dataset_hash'] = dataset_hash
+        return self._send_msg(data)
+
+    def _test_publish(self, algorithm_name='Linear Regrission', metric_name='RMSE', metric_value='0', dataset_hash='asdfasdfasdfd'):
+        """
+        Test Function to send message to the fml backend server!
+        """
+        self._jprint(self.publish(algorithm_name, metric_name, metric_value, dataset_hash))

--- a/sklearn/fml/setup.py
+++ b/sklearn/fml/setup.py
@@ -1,0 +1,19 @@
+import os
+
+import numpy
+
+def configuration(parent_package='', top_path=None):
+    from numpy.distutils.misc_util import Configuration
+
+    config = Configuration('fml', parent_package, top_path)
+
+    libraries = []
+    if os.name == 'posix':
+        libraries.append('m')
+    
+    return config
+
+
+if __name__ == '__main__':
+    from numpy.distutils.core import setup
+    setup(**configuration(top_path='').todict())

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -37,6 +37,9 @@ from ..utils._seq_dataset import ArrayDataset64, CSRDataset64
 from ..utils.validation import check_is_fitted
 from ..preprocessing.data import normalize as f_normalize
 
+import requests as req
+import json
+
 # TODO: bayesian_ridge_regression and bayesian_regression_ard
 # should be squashed into its respective objects.
 
@@ -230,6 +233,42 @@ class LinearModel(BaseEstimator, metaclass=ABCMeta):
             self.intercept_ = y_offset - np.dot(X_offset, self.coef_.T)
         else:
             self.intercept_ = 0.
+
+    def _jprint(self, obj):
+        # create a formatted string of the Python JSON object
+        text = json.dumps(obj, sort_keys=True, indent=4)
+        print(text)
+
+    def test_publish(self, algorithm_name = 'Linear Regrission', metric_name = 'RMSE', metric_value = '0', dataset_hash = 'asdfasdfasdfd'):
+        """
+        Test Function to send message to the fml backend server!
+        """
+        data = {}
+        data['algorithm_name'] = algorithm_name
+        data['metric_name'] = metric_name
+        data['metric_value'] = metric_value
+        data['dataset_hash'] = dataset_hash
+        self._jprint(self._send_msg(data))
+
+    def _publish(self, algorithm_name, metric_name, metric_value, dataset_hash):
+        """
+        Publishes the data collected to the federated meta learning API
+        """
+        data = {}
+        data['algorithm_name'] = algorithm_name
+        data['metric_name'] = metric_name
+        data['metric_value'] = metric_value
+        data['dataset_hash'] = dataset_hash
+        return self._send_msg(data)
+
+    def _send_msg(self, data):
+        """
+        API call to the federated meta learning server
+        """
+        url = 'http://127.0.0.1:5000/metric'
+        res = req.post(url, json=data)
+        print(res.status_code)
+        return res.json()
 
 
 # XXX Should this derive from LinearModel? It should be a mixin, not an ABC.

--- a/sklearn/linear_model/base.py
+++ b/sklearn/linear_model/base.py
@@ -37,9 +37,6 @@ from ..utils._seq_dataset import ArrayDataset64, CSRDataset64
 from ..utils.validation import check_is_fitted
 from ..preprocessing.data import normalize as f_normalize
 
-import requests as req
-import json
-
 # TODO: bayesian_ridge_regression and bayesian_regression_ard
 # should be squashed into its respective objects.
 
@@ -233,43 +230,6 @@ class LinearModel(BaseEstimator, metaclass=ABCMeta):
             self.intercept_ = y_offset - np.dot(X_offset, self.coef_.T)
         else:
             self.intercept_ = 0.
-
-    def _jprint(self, obj):
-        # create a formatted string of the Python JSON object
-        text = json.dumps(obj, sort_keys=True, indent=4)
-        print(text)
-
-    def test_publish(self, algorithm_name = 'Linear Regrission', metric_name = 'RMSE', metric_value = '0', dataset_hash = 'asdfasdfasdfd'):
-        """
-        Test Function to send message to the fml backend server!
-        """
-        data = {}
-        data['algorithm_name'] = algorithm_name
-        data['metric_name'] = metric_name
-        data['metric_value'] = metric_value
-        data['dataset_hash'] = dataset_hash
-        self._jprint(self._send_msg(data))
-
-    def _publish(self, algorithm_name, metric_name, metric_value, dataset_hash):
-        """
-        Publishes the data collected to the federated meta learning API
-        """
-        data = {}
-        data['algorithm_name'] = algorithm_name
-        data['metric_name'] = metric_name
-        data['metric_value'] = metric_value
-        data['dataset_hash'] = dataset_hash
-        return self._send_msg(data)
-
-    def _send_msg(self, data):
-        """
-        API call to the federated meta learning server
-        """
-        url = 'http://127.0.0.1:5000/metric'
-        res = req.post(url, json=data)
-        print(res.status_code)
-        return res.json()
-
 
 # XXX Should this derive from LinearModel? It should be a mixin, not an ABC.
 # Maybe the n_features checking can be moved to LinearModel.

--- a/sklearn/setup.py
+++ b/sklearn/setup.py
@@ -68,6 +68,9 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('svm')
     config.add_subpackage('linear_model')
 
+    # submodules which are used for federated meta learning
+    config.add_subpackage('fml')
+
     # add cython extension module for isotonic regression
     config.add_extension('_isotonic',
                          sources=['_isotonic.pyx'],


### PR DESCRIPTION
Added **Federated Meta-Learning** `client code` into scikit-learn.

Created a new subpackage under `sklearn` package called `fml` and added code which temporarily calls the local server hosted on the machine and sends the required metadata to it.

Updated sklearn's build to reflect the addition of the new `fml` package as well.

Updated sklearn's version to `0.22.fml0`