### PR TITLE
changed the key based SHA256 to a hash based encryption

### DIFF
--- a/sklearn/fml/encryption/__init__.py
+++ b/sklearn/fml/encryption/__init__.py
@@ -2,6 +2,6 @@
 The :mod:`sklearn.fml.encryption` module implements Federated Meta Learning
 """
 
-from .key import FMLKey
+from .fml_hash import FMLHash
 
-__all__ = ['FMLKey']
+__all__ = ['FMLHash']

--- a/sklearn/fml/encryption/fml_hash.py
+++ b/sklearn/fml/encryption/fml_hash.py
@@ -1,0 +1,15 @@
+import hashlib
+
+class FMLHash:
+    def __init__(self):
+        return
+    
+    def hashVal(self, value):
+        m = hashlib.sha256()
+        m.update(value.encode())
+        return m.digest()
+        
+    def hashValAndReturnString(self, value):
+        m = hashlib.sha1()
+        m.update(value.encode())
+        return m.digest().decode("unicode_escape")

--- a/sklearn/fml/encryption/key.py
+++ b/sklearn/fml/encryption/key.py
@@ -1,7 +1,0 @@
-class FMLKey:
-    def __init__(self):
-        return
-    
-    def getKey(self):
-        return b'waI2QimsPHOT4SK9qWeHF6aTnE3wgtxL_8weR_6nrOQ='
-        

--- a/sklearn/fml/fml_client.py
+++ b/sklearn/fml/fml_client.py
@@ -1,7 +1,7 @@
 import json
 import requests as req
-from cryptography.fernet import Fernet
-from fml.encryption.key import FMLKey
+from sklearn import linear_model
+from fml.encryption.fml_hash import FMLHash
 
 
 class FMLClient:
@@ -22,14 +22,14 @@ class FMLClient:
         print(res.status_code)
         return res.json()
 
-    def publish(self, algorithm_name, metric_name, metric_value, dataset):
+    def publish(self, model, metric_name, metric_value, dataset):
         """
         Publishes the data collected to the federated meta learning API
         """
-        key = FMLKey()
-        f = Fernet(key.getKey())
+        h = FMLHash()
         # converts the dataset to a byte object and then encrypts it and converts it to string
-        dataset_hash = f.encrypt(dataset.encode()).decode("utf-8")
+        dataset_hash = h.hashValAndReturnString(dataset)
+        algorithm_name = str(model.__class__)
 
         data = {}
         data['algorithm_name'] = algorithm_name
@@ -38,8 +38,8 @@ class FMLClient:
         data['dataset_hash'] = dataset_hash
         return self._send_msg(data)
 
-    def _test_publish(self, algorithm_name='Linear Regrission', metric_name='RMSE', metric_value='0', dataset='asdfasdfasdfd'):
+    def _test_publish(self, model=linear_model.LinearRegression(), metric_name='RMSE', metric_value='0', dataset='asdfasdfasdfd'):
         """
         Test Function to send message to the fml backend server!
         """
-        self._jprint(self.publish(algorithm_name, metric_name, metric_value, dataset))
+        self._jprint(self.publish(model, metric_name, metric_value, dataset))


### PR DESCRIPTION
In relation to [issue 4](https://github.com/mukeshmk/fml-back-end/issues/4) of [Federated Meta Learning](https://github.com/mukeshmk/fml-back-end/)

Changed the currently used key-based `SHA256` to a one-time hash function.
`v1` of the project will not provide the possibility of retrieving the data back from the hash value.

Based on comments from Joeran Beel, after meeting on `02-04-2020`.

